### PR TITLE
[Minsu] Week7 미션

### DIFF
--- a/Minsu/umc10th/build.gradle
+++ b/Minsu/umc10th/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/Minsu/umc10th/keyword_summary/ch07.md
+++ b/Minsu/umc10th/keyword_summary/ch07.md
@@ -1,0 +1,31 @@
+## Page와 Slice
+
+`Page`와 `Slice`는 Spring Data에서 페이징 조회 결과를 표현하는 타입이다.  
+`Page`는 현재 페이지 데이터뿐 아니라 전체 데이터 개수, 전체 페이지 수, 첫 페이지 여부, 마지막 페이지 여부까지 제공한다.  
+이 정보를 만들기 위해 count 쿼리가 추가로 실행되므로, 전체 개수가 꼭 필요한 게시판형 화면에 적합하다.  
+`Slice`는 전체 개수는 계산하지 않고 다음 페이지가 있는지만 판단한다.  
+무한 스크롤이나 커서 페이징처럼 “다음 데이터가 있는가”만 중요할 때는 `Slice`가 더 가볍고 적합하다.
+
+## Java stream API
+
+Stream API는 컬렉션 데이터를 반복문보다 선언적으로 처리할 수 있게 해주는 Java 기능이다.  
+`stream()`, `map()`, `filter()`, `toList()` 같은 메서드를 조합해 데이터 변환과 필터링을 표현한다.  
+예를 들어 엔티티 목록을 DTO 목록으로 바꿀 때 `reviews.stream().map(ReviewConverter::toDto).toList()`처럼 사용할 수 있다.  
+코드가 짧아지고 변환 의도가 명확해지는 장점이 있다.  
+다만 stream 안에 DB 조회 같은 무거운 로직을 넣으면 N+1 문제나 성능 저하가 생길 수 있어 주의해야 한다.
+
+## 객체 그래프 탐색
+
+객체 그래프 탐색은 한 객체에서 연관된 다른 객체로 필드를 따라 이동하는 방식이다.  
+예를 들어 `review.getStore().getName()`은 리뷰에서 가게 객체로 이동한 뒤 가게 이름을 꺼내는 객체 그래프 탐색이다.  
+JPA에서는 연관관계가 지연로딩이면 이 탐색 시점에 추가 쿼리가 실행될 수 있다.  
+단건 조회에서는 자연스럽지만, 목록 조회에서 반복되면 N+1 문제가 발생할 수 있다.  
+따라서 목록 API에서는 Fetch Join, EntityGraph, 별도 IN 쿼리 등으로 필요한 연관 데이터를 미리 가져오는 설계가 중요하다.
+
+## @Valid vs @Validated
+
+`@Valid`와 `@Validated`는 요청 DTO나 객체의 Bean Validation 어노테이션을 실행하기 위해 사용하는 기능이다.  
+`@Valid`는 Jakarta Bean Validation 표준에 속하며, `@NotNull`, `@NotBlank`, `@Min` 같은 검증을 동작시킨다.  
+Spring Controller에서 `@RequestBody @Valid SomeDto dto`처럼 사용하면 요청값이 DTO 조건을 만족하는지 검사한다.  
+`@Validated`는 Spring이 제공하는 확장 기능이며, 검증 그룹을 지정하거나 클래스 레벨 메서드 파라미터 검증에 활용할 수 있다.  
+일반적인 요청 DTO 검증은 `@Valid`로 충분하고, 그룹 검증이나 서비스 메서드 검증이 필요할 때 `@Validated`를 고려한다.

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
@@ -6,8 +6,10 @@ import com.example.umc10th.domain.mission.exception.code.MissionSuccessCode;
 import com.example.umc10th.domain.mission.service.MissionService;
 import com.example.umc10th.global.apiPayload.ApiResponse;
 import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
+import com.example.umc10th.global.dto.CommonResDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,6 +43,13 @@ public class MissionController {
             @RequestParam(defaultValue = "0") Long cursor,
             @RequestParam(defaultValue = "10") int limit) {
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, missionService.getOngoingMissions(cursor, limit));
+    }
+
+    @PostMapping("/ongoing")
+    @Operation(summary = "진행중 미션 조회 (오프셋 페이징)")
+    public ApiResponse<CommonResDTO.OffsetPagination<MissionResDTO.MissionItem>> getOngoingMissionsByPage(
+            @RequestBody @Valid MissionReqDTO.GetOngoingMissions dto) {
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, missionService.getOngoingMissions(dto));
     }
 
     @GetMapping("/available")

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
@@ -25,7 +25,7 @@ public class MissionController {
     @Operation(summary = "미션 성공 요청")
     public ApiResponse<MissionResDTO.ActivatedMissionInfo> successMission(
             @PathVariable Long activatedMissionId,
-            @RequestBody MissionReqDTO.SuccessRequest dto) {
+            @RequestBody @Valid MissionReqDTO.SuccessRequest dto) {
         return ApiResponse.onSuccess(MissionSuccessCode.SUCCESS_REQUESTED, missionService.successMission(activatedMissionId, dto));
     }
 

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
@@ -4,7 +4,9 @@ import com.example.umc10th.domain.mission.enums.MissionState;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public class MissionReqDTO {
 
@@ -27,6 +29,8 @@ public class MissionReqDTO {
     public record SuccessRequest(
             @JsonProperty("approver_code")
             @Schema(description = "미션 승인 구분번호", example = "920394")
+            @NotBlank(message = "구분번호는 필수입니다.")
+            @Pattern(regexp = "\\d{6}", message = "구분번호는 6자리 숫자여야 합니다.")
             String approverCode
     ) {}
 }

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
@@ -1,9 +1,28 @@
 package com.example.umc10th.domain.mission.dto;
 
+import com.example.umc10th.domain.mission.enums.MissionState;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public class MissionReqDTO {
+
+    public record GetOngoingMissions(
+            @NotNull(message = "회원 ID는 필수입니다.")
+            Long memberId,
+
+            @NotNull(message = "미션 상태는 필수입니다.")
+            MissionState state,
+
+            @NotNull(message = "페이지 번호는 필수입니다.")
+            @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
+            Integer page,
+
+            @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+            Integer size
+    ) {
+    }
 
     public record SuccessRequest(
             @JsonProperty("approver_code")

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/repository/ActivatedMissionRepository.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/repository/ActivatedMissionRepository.java
@@ -2,7 +2,9 @@ package com.example.umc10th.domain.mission.repository;
 
 import com.example.umc10th.domain.mission.entity.ActivatedMission;
 import com.example.umc10th.domain.mission.enums.MissionState;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +14,9 @@ import java.util.List;
 public interface ActivatedMissionRepository extends JpaRepository<ActivatedMission, Long> {
 
     boolean existsByMemberIdAndMissionId(Long memberId, Long missionId);
+
+    @EntityGraph(attributePaths = {"mission", "mission.store"})
+    Page<ActivatedMission> findAllByMember_IdAndState(Long memberId, MissionState state, Pageable pageable);
 
     @Query("""
             SELECT am FROM ActivatedMission am

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
@@ -14,8 +14,12 @@ import com.example.umc10th.domain.mission.exception.MissionException;
 import com.example.umc10th.domain.mission.exception.code.MissionErrorCode;
 import com.example.umc10th.domain.mission.repository.ActivatedMissionRepository;
 import com.example.umc10th.domain.mission.repository.MissionRepository;
+import com.example.umc10th.global.converter.PaginationConverter;
+import com.example.umc10th.global.dto.CommonResDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +49,23 @@ public class MissionService {
         List<ActivatedMission> list = activatedMissionRepository
                 .findByMemberIdAndStateWithDetailsCursor(TEMP_MEMBER_ID, MissionState.ONGOING, cursor, PageRequest.of(0, limit));
         return MissionConverter.toMissionPageResult(list, limit);
+    }
+
+    public CommonResDTO.OffsetPagination<MissionResDTO.MissionItem> getOngoingMissions(
+            MissionReqDTO.GetOngoingMissions dto
+    ) {
+        memberRepository.findById(dto.memberId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        int size = dto.size() == null ? 10 : dto.size();
+        PageRequest pageRequest = PageRequest.of(dto.page(), size, Sort.by("id").descending());
+        Page<ActivatedMission> page = activatedMissionRepository
+                .findAllByMember_IdAndState(dto.memberId(), dto.state(), pageRequest);
+        List<MissionResDTO.MissionItem> data = page.getContent().stream()
+                .map(MissionConverter::toMissionItem)
+                .toList();
+
+        return PaginationConverter.toOffsetPagination(page, data);
     }
 
     public MissionResDTO.AvailableMissionPageResult getAvailableMissions(Long townId, Long cursor, int limit) {

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -6,6 +6,7 @@ import com.example.umc10th.domain.review.exception.code.ReviewSuccessCode;
 import com.example.umc10th.domain.review.service.ReviewService;
 import com.example.umc10th.global.apiPayload.ApiResponse;
 import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
+import com.example.umc10th.global.dto.CommonResDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -24,11 +25,12 @@ public class ReviewController {
 
     @GetMapping("/users/{userId}/reviews")
     @Operation(summary = "작성한 리뷰 전체 조회 (커서 페이징)")
-    public ApiResponse<ReviewResDTO.MyReviewPageResult> getMyReviews(
+    public ApiResponse<CommonResDTO.CursorPagination<ReviewResDTO.MyReviewCursorItem>> getMyReviews(
             @PathVariable Long userId,
-            @RequestParam(defaultValue = "0") Long cursor,
-            @RequestParam(defaultValue = "10") int limit) {
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, reviewService.getMyReviews(userId, cursor, limit));
+            @RequestParam(defaultValue = "-1") String cursor,
+            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam(defaultValue = "id") String query) {
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, reviewService.getMyReviews(userId, cursor, limit, query));
     }
 
     @DeleteMapping("/reviews/{reviewId}")

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -9,6 +9,7 @@ import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
 import com.example.umc10th.global.dto.CommonResDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -44,7 +45,7 @@ public class ReviewController {
     @Operation(summary = "리뷰 수정 (multipart/form-data)")
     public ApiResponse<ReviewResDTO.ReviewInfo> updateReview(
             @PathVariable Long reviewId,
-            @RequestPart(value = "request", required = false) ReviewReqDTO.Update request,
+            @RequestPart(value = "request", required = false) @Valid ReviewReqDTO.Update request,
             @RequestPart(value = "images", required = false) List<MultipartFile> images) {
         return ApiResponse.onSuccess(ReviewSuccessCode.OK, reviewService.updateReview(reviewId, request, images));
     }
@@ -53,7 +54,7 @@ public class ReviewController {
     @Operation(summary = "가게 리뷰 작성 (multipart/form-data)")
     public ApiResponse<ReviewResDTO.ReviewInfo> createReview(
             @PathVariable Long storeId,
-            @RequestPart("request") ReviewReqDTO.CreateReview request,
+            @RequestPart("request") @Valid ReviewReqDTO.CreateReview request,
             @RequestPart(value = "images", required = false) List<MultipartFile> images) {
         return ApiResponse.onSuccess(ReviewSuccessCode.CREATED, reviewService.createReview(storeId, request, images));
     }

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
@@ -23,29 +23,6 @@ public class ReviewConverter {
                 .build();
     }
 
-    public static ReviewResDTO.MyReviewItem toMyReviewItem(Review review) {
-        List<String> imgUrls = review.getImages().stream()
-                .map(ReviewImage::getImgUrl).toList();
-        return ReviewResDTO.MyReviewItem.builder()
-                .reviewId(String.valueOf(review.getId()))
-                .storeName(review.getStore().getName())
-                .rating(review.getRating())
-                .body(review.getBody())
-                .imgUrls(imgUrls)
-                .createdAt(review.getCreatedAt())
-                .build();
-    }
-
-    public static ReviewResDTO.MyReviewPageResult toMyReviewPageResult(List<Review> list, int limit) {
-        boolean hasNext = list.size() == limit;
-        String nextCursor = list.isEmpty() ? null : String.valueOf(list.get(list.size() - 1).getId());
-        return ReviewResDTO.MyReviewPageResult.builder()
-                .reviews(list.stream().map(ReviewConverter::toMyReviewItem).toList())
-                .nextCursor(nextCursor)
-                .hasNext(hasNext)
-                .build();
-    }
-
     public static ReviewResDTO.MyReviewCursorItem toMyReviewCursorItem(Review review) {
         return ReviewResDTO.MyReviewCursorItem.builder()
                 .reviewId(String.valueOf(review.getId()))

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
@@ -46,6 +46,16 @@ public class ReviewConverter {
                 .build();
     }
 
+    public static ReviewResDTO.MyReviewCursorItem toMyReviewCursorItem(Review review) {
+        return ReviewResDTO.MyReviewCursorItem.builder()
+                .reviewId(String.valueOf(review.getId()))
+                .storeName(review.getStore().getName())
+                .rating(review.getRating())
+                .body(review.getBody())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+
     public static ReviewResDTO.StoreReviewItem toStoreReviewItem(Review review) {
         List<String> imgUrls = review.getImages().stream()
                 .map(ReviewImage::getImgUrl).toList();

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
@@ -1,20 +1,33 @@
 package com.example.umc10th.domain.review.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public class ReviewReqDTO {
 
     public record CreateReview(
             @Schema(description = "별점 (1.0 ~ 5.0)", example = "4.5")
+            @NotNull(message = "별점은 필수입니다.")
+            @DecimalMin(value = "1.0", message = "별점은 1.0 이상이어야 합니다.")
+            @DecimalMax(value = "5.0", message = "별점은 5.0 이하여야 합니다.")
             Double rating,
             @Schema(description = "리뷰 내용", example = "음식이 정말 맛있고 양도 많아요!")
+            @NotBlank(message = "리뷰 내용은 필수입니다.")
+            @Size(max = 500, message = "리뷰 내용은 500자 이내여야 합니다.")
             String body
     ) {}
 
     public record Update(
             @Schema(description = "별점 (1.0 ~ 5.0)", example = "4.0")
+            @DecimalMin(value = "1.0", message = "별점은 1.0 이상이어야 합니다.")
+            @DecimalMax(value = "5.0", message = "별점은 5.0 이하여야 합니다.")
             Double rating,
             @Schema(description = "리뷰 내용", example = "수정된 리뷰 내용입니다.")
+            @Size(max = 500, message = "리뷰 내용은 500자 이내여야 합니다.")
             String body
     ) {}
 }

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
@@ -59,6 +59,23 @@ public class ReviewResDTO {
     ) {}
 
     @Builder
+    public record MyReviewCursorItem(
+            @JsonProperty("review_id")
+            @Schema(description = "리뷰 ID", example = "10")
+            String reviewId,
+            @JsonProperty("store_name")
+            @Schema(description = "가게 이름", example = "반이학생마라탕")
+            String storeName,
+            @Schema(description = "별점", example = "4.5")
+            Double rating,
+            @Schema(description = "리뷰 내용", example = "너무 맛있어요! 다음에 또 올게요.")
+            String body,
+            @JsonProperty("created_at")
+            @Schema(description = "작성 시각", example = "2022-05-14T10:00:00")
+            LocalDateTime createdAt
+    ) {}
+
+    @Builder
     public record OwnerReply(
             @Schema(description = "사장님 답글", example = "감사합니다. 다음에 또 방문해 주세요!")
             String body

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
@@ -30,35 +30,6 @@ public class ReviewResDTO {
     ) {}
 
     @Builder
-    public record MyReviewItem(
-            @JsonProperty("review_id")
-            @Schema(description = "리뷰 ID", example = "10")
-            String reviewId,
-            @JsonProperty("store_name")
-            @Schema(description = "가게 이름", example = "반이학생마라탕")
-            String storeName,
-            @Schema(description = "별점", example = "4.5")
-            Double rating,
-            @Schema(description = "리뷰 내용", example = "너무 맛있어요! 다음에 또 올게요.")
-            String body,
-            @JsonProperty("img_urls")
-            @Schema(description = "이미지 URL 목록", example = "[\"https://example.com/img1.jpg\"]")
-            List<String> imgUrls,
-            @JsonProperty("created_at")
-            @Schema(description = "작성 시각", example = "2022-05-14T10:00:00")
-            LocalDateTime createdAt
-    ) {}
-
-    @Builder
-    public record MyReviewPageResult(
-            List<MyReviewItem> reviews,
-            @Schema(description = "다음 페이지 커서", example = "10")
-            String nextCursor,
-            @Schema(description = "다음 페이지 존재 여부", example = "true")
-            Boolean hasNext
-    ) {}
-
-    @Builder
     public record MyReviewCursorItem(
             @JsonProperty("review_id")
             @Schema(description = "리뷰 ID", example = "10")

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReviewErrorCode implements BaseErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "해당 리뷰를 찾을 수 없습니다."),
-    REVIEW_NOT_OWNED(HttpStatus.FORBIDDEN, "REVIEW403_1", "해당 리뷰에 대한 권한이 없습니다.");
+    REVIEW_NOT_OWNED(HttpStatus.FORBIDDEN, "REVIEW403_1", "해당 리뷰에 대한 권한이 없습니다."),
+    QUERY_NOT_VALID(HttpStatus.BAD_REQUEST, "REVIEW400_1", "지원하지 않는 리뷰 정렬 조건입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum ReviewErrorCode implements BaseErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "해당 리뷰를 찾을 수 없습니다."),
     REVIEW_NOT_OWNED(HttpStatus.FORBIDDEN, "REVIEW403_1", "해당 리뷰에 대한 권한이 없습니다."),
-    QUERY_NOT_VALID(HttpStatus.BAD_REQUEST, "REVIEW400_1", "지원하지 않는 리뷰 정렬 조건입니다.");
+    QUERY_NOT_VALID(HttpStatus.BAD_REQUEST, "REVIEW400_1", "지원하지 않는 리뷰 정렬 조건입니다."),
+    INVALID_CURSOR(HttpStatus.BAD_REQUEST, "REVIEW400_2", "올바르지 않은 커서 형식입니다."),
+    INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "REVIEW400_3", "페이지 크기는 1 이상이어야 합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
@@ -2,6 +2,8 @@ package com.example.umc10th.domain.review.repository;
 
 import com.example.umc10th.domain.review.entity.Review;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +14,30 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT r FROM Review r WHERE r.member.id = :memberId AND r.id > :cursor ORDER BY r.id ASC")
     List<Review> findByMemberIdCursor(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"store"})
+    Slice<Review> findByMember_IdOrderByIdDesc(Long memberId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"store"})
+    Slice<Review> findByMember_IdAndIdLessThanOrderByIdDesc(Long memberId, Long idCursor, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"store"})
+    Slice<Review> findByMember_IdOrderByRatingDescIdDesc(Long memberId, Pageable pageable);
+
+    @Query("""
+            SELECT r FROM Review r
+            JOIN FETCH r.store
+            WHERE r.member.id = :memberId
+              AND (r.rating < :prevRating
+                   OR (r.rating = :prevRating AND r.id < :idCursor))
+            ORDER BY r.rating DESC, r.id DESC
+            """)
+    Slice<Review> findByRatingCursor(
+            @Param("memberId") Long memberId,
+            @Param("prevRating") Double prevRating,
+            @Param("idCursor") Long idCursor,
+            Pageable pageable
+    );
 
     @Query("""
             SELECT DISTINCT r FROM Review r

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
@@ -12,9 +12,6 @@ import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    @Query("SELECT r FROM Review r WHERE r.member.id = :memberId AND r.id > :cursor ORDER BY r.id ASC")
-    List<Review> findByMemberIdCursor(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
-
     @EntityGraph(attributePaths = {"store"})
     Slice<Review> findByMember_IdOrderByIdDesc(Long memberId, Pageable pageable);
 

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
@@ -55,6 +55,7 @@ public class ReviewService {
             int limit,
             String query
     ) {
+        validatePageSize(limit);
         memberRepository.findById(userId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
@@ -79,7 +80,7 @@ public class ReviewService {
                 case "rating" -> {
                     String[] cursorParts = cursor.split(":");
                     if (cursorParts.length != 2) {
-                        throw new ReviewException(ReviewErrorCode.QUERY_NOT_VALID);
+                        throw new ReviewException(ReviewErrorCode.INVALID_CURSOR);
                     }
                     yield reviewRepository.findByRatingCursor(
                             userId,
@@ -219,7 +220,7 @@ public class ReviewService {
         try {
             return Long.parseLong(cursor);
         } catch (NumberFormatException e) {
-            throw new ReviewException(ReviewErrorCode.QUERY_NOT_VALID);
+            throw new ReviewException(ReviewErrorCode.INVALID_CURSOR);
         }
     }
 
@@ -227,7 +228,13 @@ public class ReviewService {
         try {
             return Double.parseDouble(cursor);
         } catch (NumberFormatException e) {
-            throw new ReviewException(ReviewErrorCode.QUERY_NOT_VALID);
+            throw new ReviewException(ReviewErrorCode.INVALID_CURSOR);
+        }
+    }
+
+    private void validatePageSize(int limit) {
+        if (limit < 1) {
+            throw new ReviewException(ReviewErrorCode.INVALID_PAGE_SIZE);
         }
     }
 }

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
@@ -17,8 +17,11 @@ import com.example.umc10th.domain.store.entity.Store;
 import com.example.umc10th.domain.store.exception.StoreException;
 import com.example.umc10th.domain.store.exception.code.StoreErrorCode;
 import com.example.umc10th.domain.store.repository.StoreRepository;
+import com.example.umc10th.global.converter.PaginationConverter;
+import com.example.umc10th.global.dto.CommonResDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -46,10 +49,55 @@ public class ReviewService {
     private static final Long TEMP_MEMBER_ID = 1L;
     private static final String UPLOAD_DIR = "uploads/";
 
-    public ReviewResDTO.MyReviewPageResult getMyReviews(Long userId, Long cursor, int limit) {
-        Long targetId = userId != null ? userId : TEMP_MEMBER_ID;
-        List<Review> list = reviewRepository.findByMemberIdCursor(targetId, cursor, PageRequest.of(0, limit));
-        return ReviewConverter.toMyReviewPageResult(list, limit);
+    public CommonResDTO.CursorPagination<ReviewResDTO.MyReviewCursorItem> getMyReviews(
+            Long userId,
+            String cursor,
+            int limit,
+            String query
+    ) {
+        memberRepository.findById(userId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        PageRequest pageRequest = PageRequest.of(0, limit);
+        String normalizedQuery = query == null ? "id" : query.toLowerCase();
+        boolean firstPage = cursor == null || cursor.equals("-1") || cursor.equals("0");
+
+        Slice<Review> slice;
+        if (firstPage) {
+            slice = switch (normalizedQuery) {
+                case "id" -> reviewRepository.findByMember_IdOrderByIdDesc(userId, pageRequest);
+                case "rating" -> reviewRepository.findByMember_IdOrderByRatingDescIdDesc(userId, pageRequest);
+                default -> throw new ReviewException(ReviewErrorCode.QUERY_NOT_VALID);
+            };
+        } else {
+            slice = switch (normalizedQuery) {
+                case "id" -> reviewRepository.findByMember_IdAndIdLessThanOrderByIdDesc(
+                        userId,
+                        parseLongCursor(cursor),
+                        pageRequest
+                );
+                case "rating" -> {
+                    String[] cursorParts = cursor.split(":");
+                    if (cursorParts.length != 2) {
+                        throw new ReviewException(ReviewErrorCode.QUERY_NOT_VALID);
+                    }
+                    yield reviewRepository.findByRatingCursor(
+                            userId,
+                            parseDoubleCursor(cursorParts[0]),
+                            parseLongCursor(cursorParts[1]),
+                            pageRequest
+                    );
+                }
+                default -> throw new ReviewException(ReviewErrorCode.QUERY_NOT_VALID);
+            };
+        }
+
+        List<ReviewResDTO.MyReviewCursorItem> data = slice.getContent().stream()
+                .map(ReviewConverter::toMyReviewCursorItem)
+                .toList();
+        String nextCursor = getNextCursor(slice.getContent(), normalizedQuery);
+
+        return PaginationConverter.toCursorPagination(slice, data, nextCursor);
     }
 
     @Transactional
@@ -153,5 +201,33 @@ public class ReviewService {
             review.getImages().add(reviewImage);
         }
         reviewImageRepository.saveAll(reviewImages);
+    }
+
+    private String getNextCursor(List<Review> reviews, String query) {
+        if (reviews.isEmpty()) {
+            return null;
+        }
+
+        Review last = reviews.get(reviews.size() - 1);
+        if (query.equals("rating")) {
+            return last.getRating() + ":" + last.getId();
+        }
+        return String.valueOf(last.getId());
+    }
+
+    private Long parseLongCursor(String cursor) {
+        try {
+            return Long.parseLong(cursor);
+        } catch (NumberFormatException e) {
+            throw new ReviewException(ReviewErrorCode.QUERY_NOT_VALID);
+        }
+    }
+
+    private Double parseDoubleCursor(String cursor) {
+        try {
+            return Double.parseDouble(cursor);
+        } catch (NumberFormatException e) {
+            throw new ReviewException(ReviewErrorCode.QUERY_NOT_VALID);
+        }
     }
 }

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/global/apiPayload/exception/handler/GeneralExceptionAdvice.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/global/apiPayload/exception/handler/GeneralExceptionAdvice.java
@@ -5,8 +5,12 @@ import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
 import com.example.umc10th.global.apiPayload.code.GeneralErrorCode;
 import com.example.umc10th.global.apiPayload.exception.ProjectException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GeneralExceptionAdvice {
@@ -17,6 +21,20 @@ public class GeneralExceptionAdvice {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e
+    ) {
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors()
+                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
+
+        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ApiResponse.onFailure(code, errors));
     }
 
     @ExceptionHandler(Exception.class)

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/global/converter/PaginationConverter.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/global/converter/PaginationConverter.java
@@ -1,0 +1,35 @@
+package com.example.umc10th.global.converter;
+
+import com.example.umc10th.global.dto.CommonResDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public class PaginationConverter {
+
+    public static <T> CommonResDTO.OffsetPagination<T> toOffsetPagination(Page<?> page, List<T> data) {
+        return CommonResDTO.OffsetPagination.<T>builder()
+                .data(data)
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .isFirst(page.isFirst())
+                .isLast(page.isLast())
+                .build();
+    }
+
+    public static <T> CommonResDTO.CursorPagination<T> toCursorPagination(
+            Slice<?> slice,
+            List<T> data,
+            String nextCursor
+    ) {
+        return CommonResDTO.CursorPagination.<T>builder()
+                .data(data)
+                .hasNext(slice.hasNext())
+                .nextCursor(nextCursor)
+                .pageSize(slice.getSize())
+                .build();
+    }
+}

--- a/Minsu/umc10th/src/main/java/com/example/umc10th/global/dto/CommonResDTO.java
+++ b/Minsu/umc10th/src/main/java/com/example/umc10th/global/dto/CommonResDTO.java
@@ -1,0 +1,29 @@
+package com.example.umc10th.global.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public class CommonResDTO {
+
+    @Builder
+    public record OffsetPagination<T>(
+            List<T> data,
+            Integer pageNumber,
+            Integer pageSize,
+            Long totalElements,
+            Integer totalPages,
+            Boolean isFirst,
+            Boolean isLast
+    ) {
+    }
+
+    @Builder
+    public record CursorPagination<T>(
+            List<T> data,
+            Boolean hasNext,
+            String nextCursor,
+            Integer pageSize
+    ) {
+    }
+}

--- a/Minsu/umc10th/src/test/java/com/example/umc10th/domain/review/converter/ReviewConverterTest.java
+++ b/Minsu/umc10th/src/test/java/com/example/umc10th/domain/review/converter/ReviewConverterTest.java
@@ -1,0 +1,41 @@
+package com.example.umc10th.domain.review.converter;
+
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.domain.review.entity.Review;
+import com.example.umc10th.domain.store.entity.Store;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ReviewConverterTest {
+
+    @Test
+    void myReviewCursorItemDoesNotExposeImages() {
+        Store store = Store.builder()
+                .id(1L)
+                .name("반이학생마라탕")
+                .build();
+        Member member = Member.builder()
+                .id(1L)
+                .name("민수")
+                .email("minsu@example.com")
+                .build();
+        Review review = Review.builder()
+                .id(10L)
+                .member(member)
+                .store(store)
+                .rating(4.5)
+                .body("맛있어요")
+                .build();
+
+        ReviewResDTO.MyReviewCursorItem result = ReviewConverter.toMyReviewCursorItem(review);
+
+        assertEquals("10", result.reviewId());
+        assertEquals("반이학생마라탕", result.storeName());
+        assertEquals(4.5, result.rating());
+        assertEquals("맛있어요", result.body());
+        assertNull(result.createdAt());
+    }
+}

--- a/Minsu/umc10th/src/test/java/com/example/umc10th/global/converter/PaginationConverterTest.java
+++ b/Minsu/umc10th/src/test/java/com/example/umc10th/global/converter/PaginationConverterTest.java
@@ -1,0 +1,47 @@
+package com.example.umc10th.global.converter;
+
+import com.example.umc10th.global.dto.CommonResDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PaginationConverterTest {
+
+    @Test
+    void offsetPaginationUsesPageMetadata() {
+        PageRequest pageRequest = PageRequest.of(1, 2);
+        PageImpl<String> page = new PageImpl<>(List.of("a", "b"), pageRequest, 5);
+
+        CommonResDTO.OffsetPagination<String> result =
+                PaginationConverter.toOffsetPagination(page, page.getContent());
+
+        assertEquals(List.of("a", "b"), result.data());
+        assertEquals(1, result.pageNumber());
+        assertEquals(2, result.pageSize());
+        assertEquals(5, result.totalElements());
+        assertEquals(3, result.totalPages());
+        assertFalse(result.isFirst());
+        assertFalse(result.isLast());
+    }
+
+    @Test
+    void cursorPaginationUsesSliceMetadata() {
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        SliceImpl<String> slice = new SliceImpl<>(List.of("a", "b"), pageRequest, true);
+
+        CommonResDTO.CursorPagination<String> result =
+                PaginationConverter.toCursorPagination(slice, slice.getContent(), "2");
+
+        assertEquals(List.of("a", "b"), result.data());
+        assertTrue(result.hasNext());
+        assertEquals("2", result.nextCursor());
+        assertEquals(2, result.pageSize());
+    }
+}


### PR DESCRIPTION
## 🔗 연관 이슈

#77 

## 🛠 작업 내용

- 진행중 미션 조회 — POST /api/v1/members/me/missions/inprogress, Request Body의 memberId 기반 오프셋 페이지네이션 구현
- 리뷰 목록 조회 — GET /api/v1/members/{memberId}/reviews, 커서 기반 페이지네이션과 ID순/별점순 정렬 지원
- 유효성 검증 — @Valid, @Validated, MethodArgumentNotValidException, ConstraintViolationException 기반 검증 응답 처리
- 구조 정리 — 공통 페이지네이션 DTO를 글로벌로 분리하고, DTO 변환 로직을 도메인별 Converter로 이동
- 스키마/타입 개선 — user를 member로 통일하고, Gender enum 및 rating 범위 검증을 적용


## 🖼 스크린샷 (선택)

<!-- UI 변경이 있는 경우에만 이미지 또는 설명을 추가해주세요. -->

## 👀 리뷰 요구사항 (선택)

<!-- 리뷰어가 특히 봐주었으면 하는 부분, 고민한 부분, 확인이 필요한 부분을 작성해주세요. -->

## 🤖 AI 활용
- [ ] AI 사용 안 함
- [x] 코드 작성 아이디어 참고
- [ ] 테스트/리팩토링 보조
- [ ] 문서/주석 작성 보조
- [x] 기타 (아래에 간단히 작성)

### 💬 나의 프롬프트

<!-- AI에게 어떤 질문을 했는지 작성해주세요. -->
AI에게 과제를 수행하면서 필요한 스킬을 먼저 분석 시킨 다음에 해당 스킬을 만들어서 과제를 수행했다.

### 🧠 AI 응답

<!-- AI가 어떤 답변을 줬는지 핵심 내용을 작성해주세요. -->
  1. Spring Study Step Runner
      - 5단계 작업처럼 “한 단계 구현 → 빌드 검증 → 추천 커밋 메시지 → 대기” 흐름을 자동으로 지키는 skill.
      - 스터디 과제처럼 커밋 단위가 중요한 레포에 잘 맞는다.
  2. Spring API Spec Refactor
      - API 명세를 보고 Controller, Service, Repository, DTO, Converter 변경 범위를 나누는 skill.
      - /api/v1/... 경로, Request Body, pagination, validation 같은 반복 패턴을 표준화할 수 있다.
  3. Spring Validation Checker
      - DTO에 @NotNull, @NotBlank, @Min, @DecimalMin, @DecimalMax 등이 빠졌는지 점검하는 skill.
      - @Valid, @Validated, 예외 핸들러까지 함께 확인하면 좋다.
  4. JPA Pagination Builder
      - Page/Slice, offset/cursor pagination, 정렬 조건, nextCursor 생성 규칙을 구현하는 skill.
      - 특히 ID순, 별점순 같은 복합 커서 조건을 매번 실수 없이 만들 수 있다.


### ✅ 내가 최종 선택한 방법 (이유)

<!-- AI 응답 중 무엇을 채택했고, 왜 그 방안을 선택했는지 작성해주세요. -->
현재 과제 뿐만 아니라 앞으로의 과제에서도 자동화를 시킬 수 있을 것 같아서 채택했다. 특히 Spring Study Step Runner는 유용하게 사용할 것 같다.

### 💡 나만의 Tip (선택)

<!-- "AI를 이렇게 사용했더니 좋더라!"하는 내용이 있다면 팀원에게 공유해주세요. -->
